### PR TITLE
Update menu

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -9,11 +9,11 @@ main:
       - name: Documentation
         url: https://docs.riskdatalibrary.org/en/latest/
         weight: 1
-      - name: Repository
-        url: https://github.com/GFDRR/rdl-standard
+      - name: Create RDLS metadata 
+        url: /create/
         weight: 2
-      - name: Conversion & validation tool
-        url: https://metadata.riskdatalibrary.org/
+      - name: Contribute to development
+        url: /contribute/
         weight: 3
       - name: Steering Committee
         url: https://github.com/GFDRR/rdl-standard/tree/0.2-dev/SteeringCommittee


### PR DESCRIPTION
reworked menu - instead of heading to the main repo, it gives more readable information from repo readme file. ('contribute' page)

Adds MDE to a renamed 'Create metadata page' where both input tools are presented with context